### PR TITLE
feat: add `tracing` as a logging backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "slint-interpreter",
  "smithay-client-toolkit 0.20.0",
  "thiserror 2.0.17",
+ "tracing",
  "wayland-client",
  "wayland-protocols",
  "xkbcommon 0.9.0",
@@ -2018,6 +2019,7 @@ dependencies = [
  "log",
  "spin_on",
  "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
@@ -3873,9 +3875,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3885,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3896,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ workspace = true
 [dependencies]
 layer-shika-composition.workspace = true
 
+[features]
+default = ["use-log"]
+use-log = ["layer-shika-composition/use-log"]
+use-tracing = ["layer-shika-composition/use-tracing"]
+
 [workspace]
 resolver = "2"
 members = [
@@ -59,13 +64,14 @@ slint-interpreter = { version = "1.14.1", default-features = false, features = [
 ] }
 smithay-client-toolkit = "0.20.0"
 thiserror = "2.0.17"
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 wayland-client = "0.31.11"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
 xkbcommon = { version = "0.9.0", features = ["wayland"] }
 
 layer-shika-domain = { version = "0.3.1", path = "crates/domain" }
-layer-shika-adapters = { version = "0.3.1", path = "crates/adapters" }
-layer-shika-composition = { version = "0.3.1", path = "crates/composition" }
+layer-shika-adapters = { version = "0.3.1", path = "crates/adapters", default-features = false }
+layer-shika-composition = { version = "0.3.1", path = "crates/composition", default-features = false }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -16,12 +16,18 @@ workspace = true
 [dependencies]
 glutin.workspace = true
 layer-shika-domain.workspace = true
-log.workspace = true
+log = { workspace = true, optional = true }
 raw-window-handle.workspace = true
 slint.workspace = true
 slint-interpreter.workspace = true
 smithay-client-toolkit.workspace = true
 thiserror.workspace = true
+tracing = { workspace = true, optional = true }
 wayland-client.workspace = true
 wayland-protocols.workspace = true
 xkbcommon.workspace = true
+
+[features]
+default = ["use-log"]
+use-log = ["dep:log"]
+use-tracing = ["dep:tracing"]

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -16,6 +16,17 @@ pub use wayland::surfaces::app_state::AppState;
 pub use wayland::surfaces::popup_manager::PopupManager;
 pub use wayland::surfaces::surface_state::SurfaceState;
 
+pub(crate) mod logger {
+    #[cfg(all(feature = "use-log", feature = "use-tracing"))]
+    compile_error!("Cannot use both logging backend at one time");
+
+    #[cfg(feature = "use-log")]
+    pub use log::{debug, error, info, warn};
+
+    #[cfg(feature = "use-tracing")]
+    pub use tracing::{debug, error, info, warn};
+}
+
 pub mod platform {
     pub use slint;
     pub use slint_interpreter;

--- a/crates/adapters/src/rendering/egl/context.rs
+++ b/crates/adapters/src/rendering/egl/context.rs
@@ -1,4 +1,7 @@
-use crate::errors::{EGLError, LayerShikaError, Result};
+use crate::{
+    errors::{EGLError, LayerShikaError, Result},
+    logger,
+};
 use glutin::{
     api::egl::{
         config::Config,
@@ -129,9 +132,9 @@ impl Drop for EGLContext {
     fn drop(&mut self) {
         if self.context.is_current() {
             if let Err(e) = self.context.make_not_current_in_place() {
-                log::error!("Failed to make EGL context not current during cleanup: {e}");
+                logger::error!("Failed to make EGL context not current during cleanup: {e}");
             } else {
-                log::info!("Successfully made EGL context not current during cleanup");
+                logger::info!("Successfully made EGL context not current during cleanup");
             }
         }
     }

--- a/crates/adapters/src/rendering/egl/context_factory.rs
+++ b/crates/adapters/src/rendering/egl/context_factory.rs
@@ -1,13 +1,15 @@
 use super::context::EGLContext;
 use super::render_context_manager::RenderContextManager;
-use crate::errors::{EGLError, LayerShikaError, Result};
+use crate::{
+    errors::{EGLError, LayerShikaError, Result},
+    logger,
+};
 use glutin::{
     api::egl::{config::Config, display::Display, surface::Surface},
     context::ContextAttributesBuilder,
     prelude::*,
     surface::{SurfaceAttributesBuilder, WindowSurface},
 };
-use log::info;
 use raw_window_handle::{RawWindowHandle, WaylandWindowHandle};
 use slint::PhysicalSize;
 use std::{ffi::c_void, num::NonZeroU32, ptr::NonNull, rc::Rc};
@@ -24,7 +26,7 @@ impl RenderContextFactory {
     }
 
     pub fn create_context(&self, surface_id: &ObjectId, size: PhysicalSize) -> Result<EGLContext> {
-        info!("Creating shared EGL context from root context manager");
+        logger::info!("Creating shared EGL context from root context manager");
 
         let context_attributes =
             ContextAttributesBuilder::default().with_sharing(self.manager.root_context());
@@ -48,7 +50,7 @@ impl RenderContextFactory {
             .make_current(&surface)
             .map_err(|e| EGLError::MakeCurrent { source: e.into() })?;
 
-        info!("Shared EGL context created successfully from root manager");
+        logger::info!("Shared EGL context created successfully from root manager");
 
         Ok(EGLContext::from_raw(surface, context))
     }

--- a/crates/adapters/src/rendering/egl/render_context_manager.rs
+++ b/crates/adapters/src/rendering/egl/render_context_manager.rs
@@ -1,11 +1,13 @@
-use crate::errors::{EGLError, LayerShikaError, Result};
+use crate::{
+    errors::{EGLError, LayerShikaError, Result},
+    logger,
+};
 use glutin::{
     api::egl::{config::Config, context::PossiblyCurrentContext, display::Display},
     config::ConfigTemplateBuilder,
     context::ContextAttributesBuilder,
     prelude::*,
 };
-use log::{info, warn};
 use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
 use std::{ffi::c_void, ptr::NonNull, rc::Rc};
 use wayland_client::backend::ObjectId;
@@ -18,7 +20,7 @@ pub struct RenderContextManager {
 
 impl RenderContextManager {
     pub fn new(display_id: &ObjectId) -> Result<Rc<Self>> {
-        info!("Initializing RenderContextManager with independent root context");
+        logger::info!("Initializing RenderContextManager with independent root context");
 
         let display_handle = create_wayland_display_handle(display_id)?;
         let display = unsafe { Display::new(display_handle) }
@@ -29,7 +31,7 @@ impl RenderContextManager {
 
         let root_context = Self::create_root_context(&display, &config)?;
 
-        info!("RenderContextManager initialized successfully");
+        logger::info!("RenderContextManager initialized successfully");
 
         Ok(Rc::new(Self {
             display,
@@ -40,11 +42,11 @@ impl RenderContextManager {
 
     fn create_root_context(display: &Display, config: &Config) -> Result<PossiblyCurrentContext> {
         if let Ok(context) = Self::try_create_surfaceless_context(display, config) {
-            info!("Created surfaceless root EGL context");
+            logger::info!("Created surfaceless root EGL context");
             return Ok(context);
         }
 
-        warn!(
+        logger::warn!(
             "Surfaceless context not available, using workaround with make_current_surfaceless anyway"
         );
         Self::create_surfaceless_fallback(display, config)

--- a/crates/adapters/src/rendering/femtovg/main_window.rs
+++ b/crates/adapters/src/rendering/femtovg/main_window.rs
@@ -1,7 +1,9 @@
 use super::renderable_window::{RenderState, RenderableWindow};
-use crate::errors::{RenderingError, Result};
+use crate::{
+    errors::{RenderingError, Result},
+    logger,
+};
 use core::ops::Deref;
-use log::info;
 use slint::{
     PhysicalSize, Window, WindowSize,
     platform::{Renderer, WindowAdapter, WindowEvent, femtovg_renderer::FemtoVGRenderer},
@@ -49,7 +51,7 @@ impl RenderableWindow for FemtoVGWindow {
     }
 
     fn set_scale_factor(&self, scale_factor: f32) {
-        info!("Setting scale factor to {scale_factor}");
+        logger::info!("Setting scale factor to {scale_factor}");
         self.scale_factor.set(scale_factor);
         self.window()
             .dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });

--- a/crates/adapters/src/rendering/femtovg/popup_window.rs
+++ b/crates/adapters/src/rendering/femtovg/popup_window.rs
@@ -1,10 +1,10 @@
 use super::renderable_window::{RenderState, RenderableWindow};
 use crate::errors::{RenderingError, Result};
+use crate::logger;
 use crate::wayland::surfaces::popup_manager::OnCloseCallback;
 use core::ops::Deref;
 use layer_shika_domain::dimensions::LogicalSize;
 use layer_shika_domain::value_objects::handle::PopupHandle;
-use log::info;
 use slint::{
     PhysicalSize, Window, WindowSize,
     platform::{Renderer, WindowAdapter, WindowEvent, femtovg_renderer::FemtoVGRenderer},
@@ -73,27 +73,27 @@ impl PopupWindow {
     }
 
     pub(crate) fn cleanup_resources(&self) {
-        info!("Cleaning up popup window resources to break reference cycles");
+        logger::info!("Cleaning up popup window resources to break reference cycles");
 
         if let Err(e) = self.window.hide() {
-            info!("Failed to hide popup window: {e}");
+            logger::info!("Failed to hide popup window: {e}");
         }
 
         if let Some(component) = self.component_instance.borrow_mut().take() {
-            info!("Dropping ComponentInstance to break reference cycle");
+            logger::info!("Dropping ComponentInstance to break reference cycle");
             drop(component);
         }
 
-        info!("Popup window resource cleanup complete");
+        logger::info!("Popup window resource cleanup complete");
     }
 
     pub fn close_popup(&self) {
-        info!("Closing popup window - cleaning up resources");
+        logger::info!("Closing popup window - cleaning up resources");
 
         self.cleanup_resources();
 
         if let Some(handle) = self.popup_handle.get() {
-            info!("Destroying popup with handle {:?}", handle);
+            logger::info!("Destroying popup with handle {:?}", handle);
             if let Some(on_close) = self.on_close.get() {
                 on_close(handle);
             }
@@ -101,7 +101,7 @@ impl PopupWindow {
 
         self.popup_handle.set(None);
 
-        info!("Popup window cleanup complete");
+        logger::info!("Popup window cleanup complete");
     }
 
     pub fn popup_key(&self) -> Option<usize> {
@@ -109,16 +109,16 @@ impl PopupWindow {
     }
 
     pub fn mark_configured(&self) {
-        info!("Popup window marked as configured");
+        logger::info!("Popup window marked as configured");
 
         if matches!(
             self.popup_render_state.get(),
             PopupRenderState::Unconfigured
         ) {
-            info!("Transitioning from Unconfigured to ReadyDirty state");
+            logger::info!("Transitioning from Unconfigured to ReadyDirty state");
             self.popup_render_state.set(PopupRenderState::ReadyDirty);
         } else {
-            info!(
+            logger::info!(
                 "Preserving current render state to avoid overwriting: {:?}",
                 self.popup_render_state.get()
             );
@@ -133,10 +133,10 @@ impl PopupWindow {
     }
 
     pub fn set_component_instance(&self, instance: ComponentInstance) {
-        info!("Setting component instance for popup window");
+        logger::info!("Setting component instance for popup window");
         let mut comp = self.component_instance.borrow_mut();
         if comp.is_some() {
-            info!("Component instance already set for popup window - replacing");
+            logger::info!("Component instance already set for popup window - replacing");
         }
         *comp = Some(instance);
 
@@ -149,14 +149,15 @@ impl PopupWindow {
         let current_size = self.logical_size.get();
 
         if current_size == new_size {
-            info!(
+            logger::info!(
                 "Popup resize skipped - size unchanged: {}x{}",
-                width, height
+                width,
+                height
             );
             return false;
         }
 
-        info!(
+        logger::info!(
             "Requesting popup resize from {}x{} to {}x{}",
             current_size.width(),
             current_size.height(),
@@ -182,11 +183,11 @@ impl RenderableWindow for PopupWindow {
     fn render_frame_if_dirty(&self) -> Result<()> {
         match self.popup_render_state.get() {
             PopupRenderState::Unconfigured => {
-                info!("Popup not yet configured, skipping render");
+                logger::info!("Popup not yet configured, skipping render");
                 return Ok(());
             }
             PopupRenderState::Repositioning => {
-                info!("Popup repositioning in progress, skipping render");
+                logger::info!("Popup repositioning in progress, skipping render");
                 return Ok(());
             }
             PopupRenderState::ReadyClean => {
@@ -212,7 +213,7 @@ impl RenderableWindow for PopupWindow {
                 self.popup_render_state.get(),
                 PopupRenderState::NeedsRelayout
             ) {
-                info!("Popup needs relayout, requesting additional render");
+                logger::info!("Popup needs relayout, requesting additional render");
                 self.popup_render_state.set(PopupRenderState::ReadyDirty);
                 RenderableWindow::request_redraw(self);
             } else {
@@ -223,7 +224,7 @@ impl RenderableWindow for PopupWindow {
     }
 
     fn set_scale_factor(&self, scale_factor: f32) {
-        info!("Setting popup scale factor to {scale_factor}");
+        logger::info!("Setting popup scale factor to {scale_factor}");
         self.scale_factor.set(scale_factor);
         self.window()
             .dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
@@ -276,13 +277,13 @@ impl Deref for PopupWindow {
 
 impl Drop for PopupWindow {
     fn drop(&mut self) {
-        info!("PopupWindow being dropped - cleaning up resources");
+        logger::info!("PopupWindow being dropped - cleaning up resources");
 
         if let Some(component) = self.component_instance.borrow_mut().take() {
-            info!("Dropping any remaining ComponentInstance in PopupWindow::drop");
+            logger::info!("Dropping any remaining ComponentInstance in PopupWindow::drop");
             drop(component);
         }
 
-        info!("PopupWindow drop complete");
+        logger::info!("PopupWindow drop complete");
     }
 }

--- a/crates/adapters/src/rendering/slint_integration/platform.rs
+++ b/crates/adapters/src/rendering/slint_integration/platform.rs
@@ -5,7 +5,7 @@ use slint::{
 use std::cell::{OnceCell, RefCell};
 use std::rc::Rc;
 
-use crate::rendering::femtovg::main_window::FemtoVGWindow;
+use crate::{logger, rendering::femtovg::main_window::FemtoVGWindow};
 
 type PopupCreator = dyn Fn() -> Result<Rc<dyn WindowAdapter>, PlatformError>;
 
@@ -40,7 +40,7 @@ impl CustomSlintPlatform {
         F: Fn() -> Result<Rc<dyn WindowAdapter>, PlatformError> + 'static,
     {
         if self.popup_creator.set(Rc::new(creator)).is_err() {
-            log::warn!("Popup creator already set, ignoring new creator");
+            logger::warn!("Popup creator already set, ignoring new creator");
         }
     }
 }

--- a/crates/adapters/src/wayland/event_handling/app_dispatcher.rs
+++ b/crates/adapters/src/wayland/event_handling/app_dispatcher.rs
@@ -1,10 +1,10 @@
+use crate::logger;
 use crate::wayland::session_lock::LockSurfaceOutputContext;
 use crate::wayland::surfaces::app_state::AppState;
 use crate::wayland::surfaces::display_metrics::DisplayMetrics;
 use crate::wayland::surfaces::surface_state::SurfaceState;
 use layer_shika_domain::value_objects::output_handle::OutputHandle;
 use layer_shika_domain::value_objects::output_info::OutputGeometry;
-use log::{debug, info};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_shell_v1::ZwlrLayerShellV1,
     zwlr_layer_surface_v1::{self, ZwlrLayerSurfaceV1},
@@ -58,13 +58,14 @@ impl Dispatch<ZwlrLayerSurfaceV1, ()> for AppState {
                 width,
                 height,
             } => {
-                info!(
+                logger::info!(
                     "Layer surface configured with compositor size: {}x{}",
-                    width, height
+                    width,
+                    height
                 );
                 let layer_surface_id = layer_surface.id();
                 let Some(surface) = state.get_output_by_layer_surface_mut(&layer_surface_id) else {
-                    info!(
+                    logger::info!(
                         "Could not find window for layer surface {:?}",
                         layer_surface_id
                     );
@@ -111,9 +112,12 @@ impl Dispatch<WlOutput, ()> for AppState {
             } => {
                 let is_current = mode_flags.contains(wl_output::Mode::Current);
                 let is_preferred = mode_flags.contains(wl_output::Mode::Preferred);
-                info!(
+                logger::info!(
                     "WlOutput mode: {}x{} (current: {}, preferred: {})",
-                    width, height, is_current, is_preferred
+                    width,
+                    height,
+                    is_current,
+                    is_preferred
                 );
                 if is_current {
                     for surface in state.all_surfaces_for_output_mut(&output_id) {
@@ -122,10 +126,10 @@ impl Dispatch<WlOutput, ()> for AppState {
                 }
             }
             wl_output::Event::Mode { .. } => {
-                debug!("WlOutput mode event with unknown flags value");
+                logger::debug!("WlOutput mode event with unknown flags value");
             }
             wl_output::Event::Description { ref description } => {
-                info!("WlOutput description: {description:?}");
+                logger::info!("WlOutput description: {description:?}");
                 if let Some(handle) = handle {
                     if let Some(info) = state.get_output_info_mut(handle) {
                         info.set_description(description.clone());
@@ -133,7 +137,7 @@ impl Dispatch<WlOutput, ()> for AppState {
                 }
             }
             wl_output::Event::Scale { ref factor } => {
-                info!("WlOutput factor scale: {factor:?}");
+                logger::info!("WlOutput factor scale: {factor:?}");
                 if let Some(handle) = handle {
                     if let Some(info) = state.get_output_info_mut(handle) {
                         info.set_scale(*factor);
@@ -141,7 +145,7 @@ impl Dispatch<WlOutput, ()> for AppState {
                 }
             }
             wl_output::Event::Name { ref name } => {
-                info!("WlOutput name: {name:?}");
+                logger::info!("WlOutput name: {name:?}");
                 if let Some(handle) = handle {
                     if let Some(info) = state.get_output_info_mut(handle) {
                         info.set_name(name.clone());
@@ -158,7 +162,7 @@ impl Dispatch<WlOutput, ()> for AppState {
                 model,
                 transform,
             } => {
-                info!(
+                logger::info!(
                     "WlOutput geometry: x={x}, y={y}, physical_width={physical_width}, physical_height={physical_height}, subpixel={subpixel:?}, make={make:?}, model={model:?}, transform={transform:?}"
                 );
                 if let Some(handle) = handle {
@@ -176,21 +180,21 @@ impl Dispatch<WlOutput, ()> for AppState {
                 }
             }
             wl_output::Event::Done => {
-                info!("WlOutput done for output {:?}", output_id);
+                logger::info!("WlOutput done for output {:?}", output_id);
 
                 if let Some(manager) = state.output_manager() {
                     let manager_ref = manager.borrow();
                     if manager_ref.has_pending_output(&output_id) {
                         drop(manager_ref);
 
-                        info!(
+                        logger::info!(
                             "Output {:?} configuration complete, finalizing...",
                             output_id
                         );
 
                         let manager_ref = manager.borrow();
                         if let Err(e) = manager_ref.finalize_output(&output_id, state, qhandle) {
-                            info!("Failed to finalize output {:?}: {e}", output_id);
+                            logger::info!("Failed to finalize output {:?}: {e}", output_id);
                         }
                     }
                 }
@@ -444,7 +448,7 @@ impl Dispatch<WpFractionalScaleV1, ()> for AppState {
     ) {
         if let wp_fractional_scale_v1::Event::PreferredScale { scale } = event {
             let scale_float = DisplayMetrics::scale_factor_from_120ths(scale);
-            info!("Fractional scale received: {scale_float} ({scale}x)");
+            logger::info!("Fractional scale received: {scale_float} ({scale}x)");
 
             for surface in state.all_outputs_mut() {
                 surface.handle_fractional_scale(proxy, scale);
@@ -499,7 +503,7 @@ impl Dispatch<XdgPopup, ()> for AppState {
                 }
             }
             xdg_popup::Event::PopupDone => {
-                info!("XdgPopup dismissed by compositor");
+                logger::info!("XdgPopup dismissed by compositor");
                 let popup_id = xdg_popup.id();
 
                 for surface in state.all_outputs_mut() {
@@ -515,13 +519,13 @@ impl Dispatch<XdgPopup, ()> for AppState {
                 }
             }
             xdg_popup::Event::Repositioned { token } => {
-                info!("XdgPopup repositioned with token {token}");
+                logger::info!("XdgPopup repositioned with token {token}");
 
                 let popup_id = xdg_popup.id();
                 for surface in state.all_outputs_mut() {
                     if let Some(popup_manager) = surface.popup_manager() {
                         if let Some(handle) = popup_manager.find_by_xdg_popup(&popup_id) {
-                            info!("Committing popup surface after reposition");
+                            logger::info!("Committing popup surface after reposition");
                             popup_manager.commit_popup_surface(handle.key());
                             break;
                         }
@@ -572,7 +576,7 @@ impl Dispatch<WlRegistry, GlobalListContents> for AppState {
                 version,
             } => {
                 if interface == "wl_output" {
-                    info!(
+                    logger::info!(
                         "Hot-plugged output detected! Binding wl_output with name {name}, version {version}"
                     );
 
@@ -583,24 +587,24 @@ impl Dispatch<WlRegistry, GlobalListContents> for AppState {
                     if let Some(manager) = state.output_manager() {
                         let mut manager_ref = manager.borrow_mut();
                         let handle = manager_ref.register_output(output, qhandle);
-                        info!("Registered hot-plugged output with handle {handle:?}");
+                        logger::info!("Registered hot-plugged output with handle {handle:?}");
 
                         state.register_registry_name(name, output_id);
                         if let Err(err) =
                             state.handle_output_added_for_lock(&output_for_lock, qhandle)
                         {
-                            info!("Failed to add session lock surface for output: {err}");
+                            logger::info!("Failed to add session lock surface for output: {err}");
                         }
                     } else {
-                        info!("No output manager available yet (startup initialization)");
+                        logger::info!("No output manager available yet (startup initialization)");
                     }
                 }
             }
             Event::GlobalRemove { name } => {
-                info!("Registry global removed: name {name}");
+                logger::info!("Registry global removed: name {name}");
 
                 if let Some(output_id) = state.unregister_registry_name(name) {
-                    info!("Output with registry name {name} removed, cleaning up...");
+                    logger::info!("Output with registry name {name} removed, cleaning up...");
 
                     state.handle_output_removed_for_lock(&output_id);
 
@@ -706,7 +710,7 @@ macro_rules! impl_empty_dispatch_app {
                     _conn: &Connection,
                     _qhandle: &QueueHandle<Self>,
                 ) {
-                  debug!("Implement empty dispatch event for {:?}", stringify!($t));
+                  logger::debug!("Implement empty dispatch event for {:?}", stringify!($t));
                 }
             }
         )+

--- a/crates/adapters/src/wayland/event_handling/event_dispatcher.rs
+++ b/crates/adapters/src/wayland/event_handling/event_dispatcher.rs
@@ -1,7 +1,7 @@
 use crate::wayland::surfaces::keyboard_state::{KeyboardState, keysym_to_text};
 use crate::wayland::surfaces::pointer_utils::wayland_button_to_slint;
 use crate::wayland::surfaces::surface_state::SurfaceState;
-use log::info;
+use crate::logger;
 use slint::{
     PhysicalSize,
     platform::WindowEvent,
@@ -41,7 +41,7 @@ impl SurfaceState {
         width: u32,
         height: u32,
     ) {
-        info!("Layer surface configured with compositor size: {width}x{height}");
+        logger::info!("Layer surface configured with compositor size: {width}x{height}");
         layer_surface.ack_configure(serial);
 
         let output_width = self.output_size().width;
@@ -70,7 +70,7 @@ impl SurfaceState {
 
         let clamped_width = target_width.min(output_width);
 
-        info!(
+        logger::info!(
             "Using dimensions: {}x{} (clamped from {}x{}, output: {}x{})",
             clamped_width,
             target_height,
@@ -85,11 +85,11 @@ impl SurfaceState {
 
     #[allow(clippy::unused_self)]
     pub(crate) fn handle_layer_surface_closed(&mut self) {
-        info!("Layer surface closed");
+        logger::info!("Layer surface closed");
     }
 
     pub(crate) fn handle_output_mode(&mut self, width: i32, height: i32) {
-        info!("WlOutput size changed to {width}x{height}");
+        logger::info!("WlOutput size changed to {width}x{height}");
         let width = width.try_into().unwrap_or_default();
         let height = height.try_into().unwrap_or_default();
         self.set_output_size(PhysicalSize::new(width, height));
@@ -219,7 +219,7 @@ impl SurfaceState {
     pub(crate) fn handle_fractional_scale(&mut self, proxy: &WpFractionalScaleV1, scale: u32) {
         use crate::wayland::surfaces::display_metrics::DisplayMetrics;
         let scale_float = DisplayMetrics::scale_factor_from_120ths(scale);
-        info!("Fractional scale received: {scale_float} ({scale}x)");
+        logger::info!("Fractional scale received: {scale_float} ({scale}x)");
         self.update_scale_for_fractional_scale_object(proxy, scale);
     }
 
@@ -231,12 +231,12 @@ impl SurfaceState {
         width: i32,
         height: i32,
     ) {
-        info!("XdgPopup Configure: position=({x}, {y}), size=({width}x{height})");
+        logger::info!("XdgPopup Configure: position=({x}, {y}), size=({width}x{height})");
 
         if let Some(popup_manager) = self.popup_manager() {
             let popup_id = xdg_popup.id();
             if let Some(handle) = popup_manager.find_by_xdg_popup(&popup_id) {
-                info!(
+                logger::info!(
                     "Marking popup with handle {handle:?} as configured after XdgPopup::Configure"
                 );
                 popup_manager.mark_popup_configured(handle.key());
@@ -247,7 +247,7 @@ impl SurfaceState {
     }
 
     pub(crate) fn handle_xdg_popup_done(&mut self, xdg_popup: &XdgPopup) {
-        info!("XdgPopup dismissed by compositor");
+        logger::info!("XdgPopup dismissed by compositor");
         let popup_id = xdg_popup.id();
         let popup_handle = self
             .popup_manager()
@@ -255,7 +255,7 @@ impl SurfaceState {
             .and_then(|pm| pm.find_by_xdg_popup(&popup_id));
 
         if let Some(handle) = popup_handle {
-            info!("Destroying popup with handle {handle:?}");
+            logger::info!("Destroying popup with handle {handle:?}");
             if let Some(popup_manager) = self.popup_manager() {
                 let _result = popup_manager.close(handle);
             }
@@ -263,17 +263,17 @@ impl SurfaceState {
     }
 
     pub(crate) fn handle_xdg_surface_configure(&mut self, xdg_surface: &XdgSurface, serial: u32) {
-        info!("XdgSurface Configure received, sending ack with serial {serial}");
+        logger::info!("XdgSurface Configure received, sending ack with serial {serial}");
         xdg_surface.ack_configure(serial);
 
         if let Some(popup_manager) = self.popup_manager() {
-            info!("Marking all popups as dirty after Configure");
+            logger::info!("Marking all popups as dirty after Configure");
             popup_manager.mark_all_popups_dirty();
         }
     }
 
     pub(crate) fn handle_xdg_wm_base_ping(xdg_wm_base: &XdgWmBase, serial: u32) {
-        info!("XdgWmBase ping received, sending pong with serial {serial}");
+        logger::info!("XdgWmBase ping received, sending pong with serial {serial}");
         xdg_wm_base.pong(serial);
     }
 }

--- a/crates/adapters/src/wayland/globals/context.rs
+++ b/crates/adapters/src/wayland/globals/context.rs
@@ -1,8 +1,7 @@
 use crate::{
     bind_globals, errors::LayerShikaError,
     rendering::egl::render_context_manager::RenderContextManager,
-};
-use log::info;
+logger};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;
 use std::rc::Rc;
 use wayland_client::{
@@ -55,15 +54,16 @@ impl GlobalContext {
             .into_iter()
             .filter(|global| global.interface == "wl_output")
             .map(|global| {
-                info!(
+                logger::info!(
                     "Found wl_output global with name: {} at version {}",
-                    global.name, global.version
+                    global.name,
+                    global.version
                 );
                 global.name
             })
             .collect();
 
-        info!(
+        logger::info!(
             "Total unique wl_output globals found: {}",
             output_names.len()
         );
@@ -71,7 +71,7 @@ impl GlobalContext {
         let outputs: Vec<WlOutput> = output_names
             .iter()
             .map(|&name| {
-                info!("Binding wl_output with name: {}", name);
+                logger::info!("Binding wl_output with name: {}", name);
                 global_list
                     .registry()
                     .bind::<WlOutput, _, _>(name, 4, queue_handle, ())
@@ -84,7 +84,7 @@ impl GlobalContext {
             });
         }
 
-        info!("Discovered {} output(s)", outputs.len());
+        logger::info!("Discovered {} output(s)", outputs.len());
 
         let xdg_wm_base = global_list
             .bind::<XdgWmBase, _, _>(queue_handle, 1..=6, ())
@@ -103,23 +103,23 @@ impl GlobalContext {
             .ok();
 
         if xdg_wm_base.is_none() {
-            info!("xdg-shell protocol not available, popup support disabled");
+            logger::info!("xdg-shell protocol not available, popup support disabled");
         }
 
         if session_lock_manager.is_none() {
-            info!("ext-session-lock protocol not available, session lock disabled");
+            logger::info!("ext-session-lock protocol not available, session lock disabled");
         }
 
         if fractional_scale_manager.is_none() {
-            info!("Fractional scale protocol not available, using integer scaling");
+            logger::info!("Fractional scale protocol not available, using integer scaling");
         }
 
         if viewporter.is_none() {
-            info!("Viewporter protocol not available");
+            logger::info!("Viewporter protocol not available");
         }
 
         if layer_shell.is_none() {
-            info!("wlr-layer-shell protocol not available, layer surfaces disabled");
+            logger::info!("wlr-layer-shell protocol not available, layer surfaces disabled");
         }
 
         let render_context_manager = RenderContextManager::new(&connection.display().id())?;

--- a/crates/adapters/src/wayland/managed_proxies.rs
+++ b/crates/adapters/src/wayland/managed_proxies.rs
@@ -1,3 +1,4 @@
+use crate::logger;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use wayland_client::{
     protocol::{wl_keyboard::WlKeyboard, wl_pointer::WlPointer, wl_surface::WlSurface},
@@ -8,7 +9,6 @@ use wayland_protocols::wp::{
     viewporter::client::wp_viewport::WpViewport,
 };
 use std::{ops::Deref, rc::Rc};
-use log::{debug, error};
 
 pub struct ManagedWlPointer {
     pointer: Rc<WlPointer>,
@@ -35,10 +35,10 @@ impl Deref for ManagedWlPointer {
 
 impl Drop for ManagedWlPointer {
     fn drop(&mut self) {
-        debug!("Releasing WlPointer");
+        logger::debug!("Releasing WlPointer");
         self.pointer.release();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after releasing WlPointer: {e}");
+            logger::error!("Failed to flush after releasing WlPointer: {e}");
         }
     }
 }
@@ -68,10 +68,10 @@ impl Deref for ManagedWlKeyboard {
 
 impl Drop for ManagedWlKeyboard {
     fn drop(&mut self) {
-        debug!("Releasing WlKeyboard");
+        logger::debug!("Releasing WlKeyboard");
         self.keyboard.release();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after releasing WlKeyboard: {e}");
+            logger::error!("Failed to flush after releasing WlKeyboard: {e}");
         }
     }
 }
@@ -101,10 +101,10 @@ impl Deref for ManagedWlSurface {
 
 impl Drop for ManagedWlSurface {
     fn drop(&mut self) {
-        debug!("Destroying WlSurface");
+        logger::debug!("Destroying WlSurface");
         self.surface.destroy();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after destroying WlSurface: {e}");
+            logger::error!("Failed to flush after destroying WlSurface: {e}");
         }
     }
 }
@@ -138,10 +138,10 @@ impl Deref for ManagedZwlrLayerSurfaceV1 {
 
 impl Drop for ManagedZwlrLayerSurfaceV1 {
     fn drop(&mut self) {
-        debug!("Destroying ZwlrLayerSurfaceV1");
+        logger::debug!("Destroying ZwlrLayerSurfaceV1");
         self.layer_surface.destroy();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after destroying ZwlrLayerSurfaceV1: {e}");
+            logger::error!("Failed to flush after destroying ZwlrLayerSurfaceV1: {e}");
         }
     }
 }
@@ -178,10 +178,10 @@ impl Deref for ManagedWpFractionalScaleV1 {
 
 impl Drop for ManagedWpFractionalScaleV1 {
     fn drop(&mut self) {
-        debug!("Destroying WpFractionalScaleV1");
+        logger::debug!("Destroying WpFractionalScaleV1");
         self.fractional_scale.destroy();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after destroying WpFractionalScaleV1: {e}");
+            logger::error!("Failed to flush after destroying WpFractionalScaleV1: {e}");
         }
     }
 }
@@ -211,10 +211,10 @@ impl Deref for ManagedWpViewport {
 
 impl Drop for ManagedWpViewport {
     fn drop(&mut self) {
-        debug!("Destroying WpViewport");
+        logger::debug!("Destroying WpViewport");
         self.viewport.destroy();
         if let Err(e) = self.connection.flush() {
-            error!("Failed to flush after destroying WpViewport: {e}");
+            logger::error!("Failed to flush after destroying WpViewport: {e}");
         }
     }
 }

--- a/crates/adapters/src/wayland/outputs/output_manager.rs
+++ b/crates/adapters/src/wayland/outputs/output_manager.rs
@@ -12,13 +12,12 @@ use crate::{
             surface_builder::SurfaceStateBuilder,
             surface_state::SurfaceState,
         },
-    },
+    }, logger,
 };
 use layer_shika_domain::value_objects::{
     output_handle::OutputHandle,
     output_info::OutputInfo,
 };
-use log::{info, warn};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use wayland_client::{
@@ -89,7 +88,7 @@ impl OutputManager {
         let output_id = output.id();
         let handle = self.output_mapping.insert(output_id.clone());
 
-        info!(
+        logger::info!(
             "Registered new output with handle {handle:?}, id {:?}",
             output_id
         );
@@ -129,16 +128,18 @@ impl OutputManager {
         info.set_primary(is_primary);
 
         if !self.config.output_policy.should_render(&info) {
-            info!(
+            logger::info!(
                 "Skipping output {:?} due to output policy (primary: {})",
-                output_id, is_primary
+                output_id,
+                is_primary
             );
             return Ok(());
         }
 
-        info!(
+        logger::info!(
             "Finalizing output {:?} (handle: {handle:?}, primary: {})",
-            output_id, is_primary
+            output_id,
+            is_primary
         );
 
         let (surface, main_surface_id) =
@@ -230,20 +231,20 @@ impl OutputManager {
 
     pub fn remove_output(&mut self, output_id: &ObjectId, app_state: &mut AppState) {
         if let Some(handle) = self.output_mapping.remove(output_id) {
-            info!("Removing output {handle:?} (id: {output_id:?})");
+            logger::info!("Removing output {handle:?} (id: {output_id:?})");
 
             let removed_windows = app_state.remove_output(handle);
             if removed_windows.is_empty() {
-                warn!("No window found for output handle {handle:?}");
+                logger::warn!("No window found for output handle {handle:?}");
             } else {
-                info!(
+                logger::info!(
                     "Cleaned up {} window(s) for output {handle:?}",
                     removed_windows.len()
                 );
             }
         } else {
             self.pending_outputs.borrow_mut().remove(output_id);
-            info!("Removed pending output {output_id:?}");
+            logger::info!("Removed pending output {output_id:?}");
         }
     }
 

--- a/crates/adapters/src/wayland/session_lock/lock_surface.rs
+++ b/crates/adapters/src/wayland/session_lock/lock_surface.rs
@@ -1,5 +1,4 @@
-use crate::wayland::session_lock::lock_context::LockSurfaceParams;
-use log::info;
+use crate::{logger, wayland::session_lock::lock_context::LockSurfaceParams};
 use std::rc::Rc;
 use wayland_client::{Proxy, backend::ObjectId, protocol::wl_surface::WlSurface};
 use wayland_protocols::ext::session_lock::v1::client::ext_session_lock_surface_v1::ExtSessionLockSurfaceV1;
@@ -28,12 +27,12 @@ impl LockSurface {
         ));
 
         let fractional_scale = params.fractional_scale_manager.map(|manager| {
-            info!("Creating fractional scale object for lock surface");
+            logger::info!("Creating fractional scale object for lock surface");
             Rc::new(manager.get_fractional_scale(&surface, params.queue_handle, ()))
         });
 
         let viewport = params.viewporter.map(|vp| {
-            info!("Creating viewport for lock surface");
+            logger::info!("Creating viewport for lock surface");
             Rc::new(vp.get_viewport(&surface, params.queue_handle, ()))
         });
 
@@ -51,7 +50,7 @@ impl LockSurface {
     }
 
     pub fn handle_configure(&mut self, serial: u32, width: u32, height: u32) {
-        info!("Lock surface configured with compositor size: {width}x{height}");
+        logger::info!("Lock surface configured with compositor size: {width}x{height}");
         self.session_surface.ack_configure(serial);
         self.width = width;
         self.height = height;

--- a/crates/adapters/src/wayland/session_lock/manager/mod.rs
+++ b/crates/adapters/src/wayland/session_lock/manager/mod.rs
@@ -4,17 +4,19 @@ pub mod lifecycle;
 pub mod rendering;
 pub mod state;
 
-use crate::errors::{LayerShikaError, Result};
 use crate::rendering::slint_integration::platform::CustomSlintPlatform;
 use crate::wayland::rendering::RenderableSet;
 use crate::wayland::session_lock::lock_context::SessionLockContext;
 use crate::wayland::session_lock::lock_surface::LockSurface;
 use crate::wayland::surfaces::app_state::AppState;
 use crate::wayland::surfaces::keyboard_state::KeyboardState;
+use crate::{
+    errors::{LayerShikaError, Result},
+    logger,
+};
 use layer_shika_domain::prelude::OutputInfo;
 use layer_shika_domain::value_objects::lock_config::LockConfig;
 use layer_shika_domain::value_objects::lock_state::LockState;
-use log::info;
 use slint_interpreter::{CompilationResult, ComponentDefinition, ComponentInstance};
 use std::rc::Rc;
 use wayland_client::{
@@ -118,7 +120,7 @@ impl SessionLockManager {
 
     pub fn handle_locked(&mut self) {
         if self.state == LockState::Locking {
-            info!("Session lock transitioned to Locked");
+            logger::info!("Session lock transitioned to Locked");
             self.state = LockState::Locked;
         }
     }
@@ -147,7 +149,7 @@ impl SessionLockManager {
     }
 
     pub fn handle_finished(&mut self) {
-        info!("Session lock finished");
+        logger::info!("Session lock finished");
         self.lock_surfaces.clear();
         self.session_lock = None;
         self.state = LockState::Inactive;
@@ -174,7 +176,7 @@ impl SessionLockManager {
             });
         };
 
-        info!("Adding lock surface for output {output_id:?}");
+        logger::info!("Adding lock surface for output {output_id:?}");
         let params = LockSurfaceParams {
             compositor: self.context.compositor(),
             output,
@@ -279,7 +281,7 @@ impl SessionLockManager {
         let component_name = self.component_definition.name().to_string();
 
         let output_scale = output_ctx.output_info.as_ref().and_then(OutputInfo::scale);
-        info!(
+        logger::info!(
             "Lock configure: output_info present={}, output_scale={:?}",
             output_ctx.output_info.is_some(),
             output_scale

--- a/crates/adapters/src/wayland/session_lock/manager/state.rs
+++ b/crates/adapters/src/wayland/session_lock/manager/state.rs
@@ -1,5 +1,6 @@
 use super::callbacks::{LockCallbackContext, LockCallbackExt, LockPropertyOperationExt};
 use crate::errors::Result;
+use crate::logger;
 use crate::rendering::femtovg::main_window::FemtoVGWindow;
 use crate::rendering::femtovg::renderable_window::{FractionalScaleConfig, RenderableWindow};
 use crate::rendering::slint_integration::platform::CustomSlintPlatform;
@@ -9,7 +10,6 @@ use crate::wayland::surfaces::display_metrics::DisplayMetrics;
 use layer_shika_domain::surface_dimensions::SurfaceDimensions;
 use layer_shika_domain::value_objects::output_handle::OutputHandle;
 use layer_shika_domain::value_objects::output_info::OutputInfo;
-use log::info;
 use slint::{
     LogicalPosition, LogicalSize, WindowSize,
     platform::{WindowAdapter, WindowEvent},
@@ -95,12 +95,12 @@ impl ActiveLockSurface {
         let dimensions = match SurfaceDimensions::calculate(width, height, context.scale_factor) {
             Ok(dimensions) => dimensions,
             Err(err) => {
-                info!("Failed to calculate lock surface dimensions: {err}");
+                logger::info!("Failed to calculate lock surface dimensions: {err}");
                 return;
             }
         };
         let scaling_mode = self.scaling_mode();
-        info!(
+        logger::info!(
             "Lock surface dimensions: logical {}x{}, physical {}x{}, scale {}, mode {:?}",
             dimensions.logical_width(),
             dimensions.logical_height(),
@@ -162,14 +162,14 @@ impl ActiveLockSurface {
             if let Err(err) =
                 callback.apply_with_context(component.component_instance(), &callback_context)
             {
-                info!(
+                logger::info!(
                     "Failed to register lock callback '{}': {err}",
                     callback.name()
                 );
             } else if callback.should_apply(&callback_context) {
-                info!("Registered lock callback '{}'", callback.name());
+                logger::info!("Registered lock callback '{}'", callback.name());
             } else {
-                info!(
+                logger::info!(
                     "Skipping callback '{}' due to selector filter (output {:?})",
                     callback.name(),
                     context.output_handle
@@ -180,19 +180,19 @@ impl ActiveLockSurface {
         for property_op in &context.property_operations {
             if property_op.should_apply(&callback_context) {
                 if let Err(err) = property_op.apply_to_component(component.component_instance()) {
-                    info!(
+                    logger::info!(
                         "Failed to set lock property '{}': {err}",
                         property_op.name()
                     );
                 } else {
-                    info!(
+                    logger::info!(
                         "Set lock property '{}' on output {:?}",
                         property_op.name(),
                         context.output_handle
                     );
                 }
             } else {
-                info!(
+                logger::info!(
                     "Skipping property '{}' due to selector filter (output {:?}, primary={:?})",
                     property_op.name(),
                     context.output_handle,
@@ -252,7 +252,7 @@ impl ActiveLockSurface {
         if let Err(err) =
             callback.apply_with_context(component.component_instance(), &callback_context)
         {
-            info!(
+            logger::info!(
                 "Failed to register lock callback '{}': {err}",
                 callback.name()
             );
@@ -283,7 +283,7 @@ impl ActiveLockSurface {
         if let Err(err) =
             property_op.apply_with_context(component.component_instance(), &callback_context)
         {
-            info!(
+            logger::info!(
                 "Failed to set lock property '{}': {err}",
                 property_op.name()
             );
@@ -314,7 +314,7 @@ impl ActiveLockSurface {
                     dimensions.logical_height() as f32,
                     scale_factor,
                 );
-                info!(
+                logger::info!(
                     "Lock FractionalWithViewport: render scale {} (from {}), physical {}x{}",
                     config.render_scale,
                     scale_factor,

--- a/crates/adapters/src/wayland/shell_adapter.rs
+++ b/crates/adapters/src/wayland/shell_adapter.rs
@@ -1,4 +1,4 @@
-use crate::wayland::{
+use crate::{logger, wayland::{
     config::{LayerSurfaceConfig, ShellSurfaceConfig, WaylandSurfaceConfig},
     globals::context::GlobalContext,
     managed_proxies::{ManagedWlKeyboard, ManagedWlPointer},
@@ -6,15 +6,8 @@ use crate::wayland::{
     outputs::{OutputManager, OutputManagerContext},
     rendering::RenderableSet,
     session_lock::{LockPropertyOperation, OutputFilter},
-    surfaces::layer_surface::{SurfaceCtx, SurfaceSetupParams},
-    surfaces::popup_manager::{PopupContext, PopupManager},
-    surfaces::{
-        app_state::AppState,
-        event_context::SharedPointerSerial,
-        surface_builder::{PlatformWrapper, SurfaceStateBuilder},
-        surface_state::SurfaceState,
-    },
-};
+    surfaces::{app_state::AppState, event_context::SharedPointerSerial, layer_surface::{SurfaceCtx, SurfaceSetupParams}, popup_manager::{PopupContext, PopupManager}, surface_builder::{PlatformWrapper, SurfaceStateBuilder}, surface_state::SurfaceState},
+}};
 use layer_shika_domain::value_objects::handle::SurfaceHandle;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use crate::{
@@ -32,7 +25,6 @@ use layer_shika_domain::value_objects::lock_config::LockConfig;
 use layer_shika_domain::value_objects::lock_state::LockState;
 use layer_shika_domain::value_objects::output_handle::OutputHandle;
 use layer_shika_domain::value_objects::output_info::OutputInfo;
-use log::{error, info};
 use slint::{
     LogicalPosition, PhysicalSize, PlatformError, WindowPosition,
     platform::{WindowAdapter, femtovg_renderer::FemtoVGRenderer, set_platform, update_timers_and_animations},
@@ -80,7 +72,7 @@ pub struct WaylandShellSystem {
 
 impl WaylandShellSystem {
     pub fn new(config: &WaylandSurfaceConfig) -> Result<Self> {
-        info!("Initializing WindowingSystem");
+        logger::info!("Initializing WindowingSystem");
         let (connection, mut event_queue) = Self::init_wayland_connection()?;
         let event_loop =
             EventLoop::try_new().map_err(|e| EventLoopError::Creation { source: e })?;
@@ -100,7 +92,7 @@ impl WaylandShellSystem {
             return Self::new_minimal();
         }
 
-        info!(
+        logger::info!(
             "Initializing WindowingSystem with {} surface configs",
             configs.len()
         );
@@ -119,7 +111,7 @@ impl WaylandShellSystem {
     }
 
     pub fn new_minimal() -> Result<Self> {
-        info!("Initializing WindowingSystem in minimal mode (no layer surfaces)");
+        logger::info!("Initializing WindowingSystem in minimal mode (no layer surfaces)");
         let (connection, mut event_queue) = Self::init_wayland_connection()?;
         let event_loop =
             EventLoop::try_new().map_err(|e| EventLoopError::Creation { source: e })?;
@@ -178,7 +170,7 @@ impl WaylandShellSystem {
             temp_info.set_primary(is_primary);
 
             if !config.output_policy.should_render(&temp_info) {
-                info!("Skipping output {} due to output policy", index);
+                logger::info!("Skipping output {} due to output policy", index);
                 continue;
             }
 
@@ -477,7 +469,7 @@ impl WaylandShellSystem {
             .map_err(|e| LayerShikaError::PlatformSetup { source: e })?;
         app_state.set_slint_platform(Rc::clone(&platform));
 
-        info!(
+        logger::info!(
             "Minimal state initialized successfully (no layer surfaces, empty Slint platform for session locks)"
         );
 
@@ -514,9 +506,10 @@ impl WaylandShellSystem {
                 temp_info.set_primary(is_primary);
 
                 if !config.output_policy.should_render(&temp_info) {
-                    info!(
+                    logger::info!(
                         "Skipping shell surface '{}' on output {} due to output policy",
-                        shell_config.name, output_index
+                        shell_config.name,
+                        output_index
                     );
                     continue;
                 }
@@ -564,9 +557,10 @@ impl WaylandShellSystem {
                     builder = builder.with_viewport(Rc::clone(vp));
                 }
 
-                info!(
+                logger::info!(
                     "Created setup for shell surface '{}' on output {}",
-                    shell_config.name, output_index
+                    shell_config.name,
+                    output_index
                 );
 
                 setups.push(OutputSetup {
@@ -611,16 +605,16 @@ impl WaylandShellSystem {
         shared_serial: &Rc<SharedPointerSerial>,
     ) {
         let Some(first_manager) = popup_managers.first() else {
-            info!("No popup managers available");
+            logger::info!("No popup managers available");
             return;
         };
 
         if !first_manager.has_xdg_shell() {
-            info!("xdg-shell not available, popups will not be supported");
+            logger::info!("xdg-shell not available, popups will not be supported");
             return;
         }
 
-        info!(
+        logger::info!(
             "Setting up shared popup creator for {} output(s)",
             popup_managers.len()
         );
@@ -629,7 +623,7 @@ impl WaylandShellSystem {
         let serial_holder = Rc::clone(shared_serial);
 
         platform.set_popup_creator(move || {
-            info!("Popup creator called! Searching for pending popup...");
+            logger::info!("Popup creator called! Searching for pending popup...");
 
             let serial = serial_holder.get();
 
@@ -637,7 +631,7 @@ impl WaylandShellSystem {
                 popup_managers.iter().zip(layer_surfaces.iter()).enumerate()
             {
                 if popup_manager.has_pending_popup() {
-                    info!("Found pending popup in output #{}", idx);
+                    logger::info!("Found pending popup in output #{}", idx);
 
                     let popup_surface = popup_manager
                         .create_pending_popup(&queue_handle_clone, layer_surface, serial)
@@ -645,7 +639,7 @@ impl WaylandShellSystem {
                             PlatformError::Other(format!("Failed to create popup: {e}"))
                         })?;
 
-                    info!("Popup created successfully for output #{}", idx);
+                    logger::info!("Popup created successfully for output #{}", idx);
                     return Ok(popup_surface as Rc<dyn WindowAdapter>);
                 }
             }
@@ -681,14 +675,14 @@ impl WaylandShellSystem {
     }
 
     pub fn run(&mut self) -> Result<()> {
-        info!("Starting WindowingSystem main loop");
+        logger::info!("Starting WindowingSystem main loop");
 
-        info!("Processing initial Wayland configuration events");
+        logger::info!("Processing initial Wayland configuration events");
         // first roundtrip to receive initial output, globals, and surface configure events
         // second roundtrip handles any cascading configure events like fractional scaling and layer surface configures
         for i in 0..2 {
             let dispatched = self.event_queue.roundtrip(&mut self.state)?;
-            info!("Roundtrip {} dispatched {} events", i + 1, dispatched);
+            logger::info!("Roundtrip {} dispatched {} events", i + 1, dispatched);
 
             self.connection
                 .flush()
@@ -702,7 +696,7 @@ impl WaylandShellSystem {
             }
         }
 
-        info!("Initial configuration complete, requesting final render");
+        logger::info!("Initial configuration complete, requesting final render");
         for surface in self.state.all_outputs() {
             RenderableWindow::request_redraw(surface.window().as_ref());
         }
@@ -723,7 +717,7 @@ impl WaylandShellSystem {
         self.event_loop
             .run(None, &mut self.state, move |shared_data| {
                 if let Err(e) = Self::process_events(connection, event_queue, shared_data) {
-                    error!("Error processing events: {e}");
+                    logger::error!("Error processing events: {e}");
                 }
             })
             .map_err(|e| EventLoopError::Execution { source: e })?;
@@ -820,7 +814,7 @@ impl WaylandShellSystem {
     }
 
     pub fn spawn_surface(&mut self, config: &ShellSurfaceConfig) -> Result<Vec<OutputHandle>> {
-        log::info!("Spawning new surface '{}'", config.name);
+        logger::info!("Spawning new surface '{}'", config.name);
 
         let mut handles = Vec::new();
 
@@ -828,7 +822,7 @@ impl WaylandShellSystem {
             handles.push(output_handle);
         }
 
-        log::info!(
+        logger::info!(
             "Surface '{}' would spawn on {} outputs (dynamic spawning not yet fully implemented)",
             config.name,
             handles.len()
@@ -838,11 +832,11 @@ impl WaylandShellSystem {
     }
 
     pub fn despawn_surface(&mut self, surface_name: &str) -> Result<()> {
-        log::info!("Despawning surface '{}'", surface_name);
+        logger::info!("Despawning surface '{}'", surface_name);
 
         let removed = self.state.remove_surfaces_by_name(surface_name);
 
-        log::info!(
+        logger::info!(
             "Removed {} surface instances for '{}'",
             removed.len(),
             surface_name

--- a/crates/adapters/src/wayland/surfaces/display_metrics.rs
+++ b/crates/adapters/src/wayland/surfaces/display_metrics.rs
@@ -1,10 +1,10 @@
+use crate::logger;
 use layer_shika_domain::dimensions::{
     LogicalSize as DomainLogicalSize, PhysicalSize as DomainPhysicalSize,
     ScaleFactor as DomainScaleFactor,
 };
 use layer_shika_domain::errors::Result as DomainResult;
 use layer_shika_domain::surface_dimensions::SurfaceDimensions;
-use log::info;
 use slint::PhysicalSize;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -88,9 +88,11 @@ impl DisplayMetrics {
         let old_scale_factor = self.scale_factor();
 
         if (old_scale_factor - new_scale_factor).abs() > f32::EPSILON {
-            info!(
+            logger::info!(
                 "DisplayMetrics: Updating scale factor from {} to {} ({}x)",
-                old_scale_factor, new_scale_factor, scale_120ths
+                old_scale_factor,
+                new_scale_factor,
+                scale_120ths
             );
             self.surface.update_scale_factor(new_scale);
             self.recalculate_surface_size();
@@ -101,9 +103,10 @@ impl DisplayMetrics {
 
     pub fn update_output_size(&mut self, output_size: PhysicalSize) {
         if self.output_size != output_size {
-            info!(
+            logger::info!(
                 "DisplayMetrics: Updating output size from {:?} to {:?}",
-                self.output_size, output_size
+                self.output_size,
+                output_size
             );
             self.output_size = output_size;
             self.recalculate_surface_size();

--- a/crates/adapters/src/wayland/surfaces/layer_surface.rs
+++ b/crates/adapters/src/wayland/surfaces/layer_surface.rs
@@ -1,5 +1,7 @@
-use crate::wayland::{config::LayerSurfaceConfig, surfaces::app_state::AppState};
-use log::info;
+use crate::{
+    logger,
+    wayland::{config::LayerSurfaceConfig, surfaces::app_state::AppState},
+};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_shell_v1::{Layer, ZwlrLayerShellV1},
     zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
@@ -55,12 +57,12 @@ impl SurfaceCtx {
         ));
 
         let fractional_scale = setup_params.fractional_scale_manager.map(|manager| {
-            info!("Creating fractional scale object for surface");
+            logger::info!("Creating fractional scale object for surface");
             Rc::new(manager.get_fractional_scale(&surface, setup_params.queue_handle, ()))
         });
 
         let viewport = setup_params.viewporter.map(|vp| {
-            info!("Creating viewport for surface");
+            logger::info!("Creating viewport for surface");
             Rc::new(vp.get_viewport(&surface, setup_params.queue_handle, ()))
         });
 

--- a/crates/adapters/src/wayland/surfaces/popup_manager.rs
+++ b/crates/adapters/src/wayland/surfaces/popup_manager.rs
@@ -3,13 +3,13 @@ use crate::rendering::egl::context_factory::RenderContextFactory;
 use crate::rendering::femtovg::popup_window::PopupWindow;
 use crate::rendering::femtovg::renderable_window::{FractionalScaleConfig, RenderableWindow};
 use crate::wayland::surfaces::display_metrics::{DisplayMetrics, SharedDisplayMetrics};
+use crate::logger;
 use layer_shika_domain::dimensions::LogicalSize as DomainLogicalSize;
 use layer_shika_domain::surface_dimensions::SurfaceDimensions;
 use layer_shika_domain::value_objects::handle::PopupHandle;
 use layer_shika_domain::value_objects::popup_behavior::ConstraintAdjustment;
 use layer_shika_domain::value_objects::popup_config::PopupConfig;
 use layer_shika_domain::value_objects::popup_position::PopupPosition;
-use log::info;
 use slint::{platform::femtovg_renderer::FemtoVGRenderer, PhysicalSize};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use std::cell::{Cell, RefCell};
@@ -107,7 +107,7 @@ struct ActivePopup {
 
 impl Drop for ActivePopup {
     fn drop(&mut self) {
-        info!("ActivePopup being dropped - cleaning up resources");
+        logger::info!("ActivePopup being dropped - cleaning up resources");
         self.window.cleanup_resources();
         self.surface.destroy();
     }
@@ -254,9 +254,11 @@ impl PopupManager {
         })?;
 
         let scale_factor = self.scale_factor();
-        info!(
+        logger::info!(
             "Creating popup window with scale factor {scale_factor}, size=({} x {}), position={:?}",
-            params.width, params.height, params.position
+            params.width,
+            params.height,
+            params.position
         );
 
         let output_size = self.output_size();
@@ -280,7 +282,7 @@ impl PopupManager {
             popup_dimensions.physical_height(),
         );
 
-        info!("Popup physical size: {popup_size:?}");
+        logger::info!("Popup physical size: {popup_size:?}");
 
         let wayland_popup_surface =
             PopupSurface::create(&super::popup_surface::PopupSurfaceParams {
@@ -300,7 +302,7 @@ impl PopupManager {
         if params.grab {
             wayland_popup_surface.grab(&self.context.seat, params.last_pointer_serial);
         } else {
-            info!("Skipping popup grab (grab disabled in request)");
+            logger::info!("Skipping popup grab (grab disabled in request)");
             wayland_popup_surface.surface.commit();
         }
 
@@ -326,7 +328,7 @@ impl PopupManager {
         popup_window.set_popup_id(popup_id.to_handle());
 
         let config = FractionalScaleConfig::new(params.width, params.height, scale_factor);
-        info!(
+        logger::info!(
             "Popup using render scale {} (from {}), render_physical {}x{}",
             config.render_scale,
             scale_factor,
@@ -344,7 +346,7 @@ impl PopupManager {
             },
         );
 
-        info!("Popup window created successfully with id {:?}", popup_id);
+        logger::info!("Popup window created successfully with id {:?}", popup_id);
 
         Ok(popup_window)
     }
@@ -401,7 +403,7 @@ impl PopupManager {
 
     fn destroy_popup(&self, id: PopupId) {
         if let Some(_popup) = self.state.borrow_mut().popups.remove(&id) {
-            info!("Destroying popup with id {:?}", id);
+            logger::info!("Destroying popup with id {:?}", id);
             // cleanup happens automatically via ActivePopup::drop()
         }
     }
@@ -507,9 +509,11 @@ impl PopupManager {
             if let Some(popup_surface) = self.get_popup_window(popup_key) {
                 let new_scale_factor = DisplayMetrics::scale_factor_from_120ths(scale_120ths);
                 let render_scale = FractionalScaleConfig::render_scale(new_scale_factor);
-                info!(
+                logger::info!(
                     "Updating popup scale factor to {} (render scale {}, from {}x)",
-                    new_scale_factor, render_scale, scale_120ths
+                    new_scale_factor,
+                    render_scale,
+                    scale_120ths
                 );
                 popup_surface.set_scale_factor(render_scale);
                 popup_surface.request_redraw();

--- a/crates/adapters/src/wayland/surfaces/popup_surface.rs
+++ b/crates/adapters/src/wayland/surfaces/popup_surface.rs
@@ -1,7 +1,6 @@
 use layer_shika_domain::dimensions::{LogicalRect, LogicalSize as DomainLogicalSize};
 use layer_shika_domain::value_objects::popup_behavior::ConstraintAdjustment as DomainConstraintAdjustment;
 use layer_shika_domain::value_objects::popup_position::{Alignment, AnchorPoint, PopupPosition};
-use log::info;
 use slint::PhysicalSize;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use std::rc::Rc;
@@ -22,6 +21,8 @@ use wayland_protocols::xdg::shell::client::{
     xdg_surface::XdgSurface,
     xdg_wm_base::XdgWmBase,
 };
+
+use crate::logger;
 
 use super::app_state::AppState;
 
@@ -66,16 +67,16 @@ impl PopupSurface {
 
         let xdg_popup = Rc::new(xdg_surface.get_popup(None, &positioner, params.queue_handle, ()));
 
-        info!("Attaching popup to layer surface via get_popup");
+        logger::info!("Attaching popup to layer surface via get_popup");
         params.parent_layer_surface.get_popup(&xdg_popup);
 
         let fractional_scale = params.fractional_scale_manager.map(|manager| {
-            info!("Creating fractional scale object for popup surface");
+            logger::info!("Creating fractional scale object for popup surface");
             Rc::new(manager.get_fractional_scale(&surface, params.queue_handle, ()))
         });
 
         let viewport = params.viewporter.map(|vp| {
-            info!("Creating viewport for popup surface");
+            logger::info!("Creating viewport for popup surface");
             Rc::new(vp.get_viewport(&surface, params.queue_handle, ()))
         });
 
@@ -85,7 +86,7 @@ impl PopupSurface {
         if let Some(ref vp) = viewport {
             let logical_width = (params.physical_size.width as f32 / params.scale_factor) as i32;
             let logical_height = (params.physical_size.height as f32 / params.scale_factor) as i32;
-            info!(
+            logger::info!(
                 "Setting viewport destination to logical size: {}x{} (physical: {}x{}, scale: {})",
                 logical_width,
                 logical_height,
@@ -130,9 +131,11 @@ impl PopupSurface {
             params.output_bounds,
         );
 
-        info!(
+        logger::info!(
             "Popup positioning: position={:?}, calculated_top_left=({}, {})",
-            params.position, calculated_x, calculated_y
+            params.position,
+            calculated_x,
+            calculated_y
         );
 
         let logical_width_i32 = logical_width as i32;
@@ -149,16 +152,16 @@ impl PopupSurface {
     }
 
     pub fn grab(&self, seat: &WlSeat, serial: u32) {
-        info!("Grabbing popup with serial {serial}");
+        logger::info!("Grabbing popup with serial {serial}");
         self.xdg_popup.grab(seat, serial);
 
-        info!("Committing popup surface to trigger configure event");
+        logger::info!("Committing popup surface to trigger configure event");
         self.surface.commit();
     }
 
     pub fn update_viewport_size(&self, logical_width: i32, logical_height: i32) {
         if let Some(ref vp) = self.viewport {
-            log::debug!(
+            logger::debug!(
                 "Updating popup viewport destination to logical size: {}x{}",
                 logical_width,
                 logical_height
@@ -180,9 +183,12 @@ impl PopupSurface {
             self.output_bounds,
         );
 
-        info!(
+        logger::info!(
             "Repositioning popup: new_size=({}x{}), new_top_left=({}, {})",
-            logical_width, logical_height, calculated_x, calculated_y
+            logical_width,
+            logical_height,
+            calculated_x,
+            calculated_y
         );
 
         let positioner = self.xdg_wm_base.create_positioner(&self.queue_handle, ());
@@ -196,7 +202,7 @@ impl PopupSurface {
     }
 
     pub fn destroy(&self) {
-        info!("Destroying popup surface");
+        logger::info!("Destroying popup surface");
         self.xdg_popup.destroy();
         self.xdg_surface.destroy();
         self.surface.destroy();
@@ -224,7 +230,7 @@ fn compute_top_left(
             (anchor_x - ax, anchor_y - ay)
         }
         PopupPosition::Cursor { .. } | PopupPosition::RelativeToParent { .. } => {
-            log::warn!("PopupPosition variant not supported by current backend: {position:?}");
+            logger::warn!("PopupPosition variant not supported by current backend: {position:?}");
             (0.0, 0.0)
         }
     };

--- a/crates/adapters/src/wayland/surfaces/surface_renderer.rs
+++ b/crates/adapters/src/wayland/surfaces/surface_renderer.rs
@@ -4,8 +4,8 @@ use crate::wayland::managed_proxies::{
     ManagedWlSurface, ManagedZwlrLayerSurfaceV1, ManagedWpFractionalScaleV1, ManagedWpViewport,
 };
 use crate::wayland::surfaces::dimensions::SurfaceDimensionsExt;
+use crate::logger;
 use layer_shika_domain::surface_dimensions::SurfaceDimensions;
-use log::{error, info};
 use slint::PhysicalSize;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use std::rc::Rc;
@@ -97,7 +97,7 @@ impl<W: RenderableWindow> SurfaceRenderer<W> {
                     dimensions.logical_height() as f32,
                     scale_factor,
                 );
-                info!(
+                logger::info!(
                     "FractionalWithViewport: render scale {} (from {}), physical {}x{}",
                     config.render_scale,
                     scale_factor,
@@ -146,14 +146,14 @@ impl<W: RenderableWindow> SurfaceRenderer<W> {
 
     pub fn update_size(&mut self, width: u32, height: u32, scale_factor: f32) {
         if width == 0 || height == 0 {
-            info!("Skipping update_size with zero dimension: {width}x{height}");
+            logger::info!("Skipping update_size with zero dimension: {width}x{height}");
             return;
         }
 
         let dimensions = match SurfaceDimensions::calculate(width, height, scale_factor) {
             Ok(d) => d,
             Err(e) => {
-                error!("Failed to calculate surface dimensions: {e}");
+                logger::error!("Failed to calculate surface dimensions: {e}");
                 return;
             }
         };
@@ -177,7 +177,7 @@ impl<W: RenderableWindow> SurfaceRenderer<W> {
             _ => dimensions.to_slint_physical_size(),
         };
 
-        info!(
+        logger::info!(
             "Updating window size: logical {}x{}, physical {}x{}, render_physical {}x{}, scale {}, buffer_scale {}, mode {:?}",
             dimensions.logical_width(),
             dimensions.logical_height(),
@@ -193,7 +193,7 @@ impl<W: RenderableWindow> SurfaceRenderer<W> {
         self.configure_slint_window(&dimensions, scaling_mode, scale_factor);
         self.configure_wayland_surface(&dimensions, scaling_mode);
 
-        info!("Window physical size: {:?}", self.window.size());
+        logger::info!("Window physical size: {:?}", self.window.size());
 
         self.size = render_physical_size;
         self.logical_size = dimensions.to_slint_logical_size();

--- a/crates/composition/Cargo.toml
+++ b/crates/composition/Cargo.toml
@@ -16,6 +16,12 @@ workspace = true
 [dependencies]
 layer-shika-adapters.workspace = true
 layer-shika-domain.workspace = true
-log.workspace = true
+log = { workspace = true, optional = true }
 spin_on.workspace = true
 thiserror.workspace = true
+tracing = { workspace = true, optional = true }
+
+[features]
+default = ["use-log"]
+use-log = ["dep:log", "layer-shika-adapters/use-log"]
+use-tracing = ["dep:tracing", "layer-shika-adapters/use-tracing"]

--- a/crates/composition/src/lib.rs
+++ b/crates/composition/src/lib.rs
@@ -61,6 +61,17 @@ pub use surface_registry::{SurfaceDefinition, SurfaceEntry, SurfaceMetadata, Sur
 
 pub use shell_config::{CompiledUiSource, ShellConfig, SurfaceComponentConfig};
 
+pub(crate) mod logger {
+    #[cfg(all(feature = "use-log", feature = "use-tracing"))]
+    compile_error!("Cannot use both logging backend at one time");
+
+    #[cfg(feature = "use-log")]
+    pub use log::{debug, error, info, warn};
+
+    #[cfg(feature = "use-tracing")]
+    pub use tracing::{debug, error, info, warn};
+}
+
 pub mod calloop {
     pub use layer_shika_adapters::platform::calloop::*;
 }

--- a/crates/composition/src/lock_selection.rs
+++ b/crates/composition/src/lock_selection.rs
@@ -1,7 +1,7 @@
 // TODO: Maybe refactor to reuse the layer shell selector
 
 use crate::{
-    Error,
+    Error, logger,
     selector::{Selector, SurfaceInfo},
     slint_interpreter::{ComponentInstance, Value},
 };
@@ -83,7 +83,11 @@ impl<'a> LockSelection<'a> {
                 match component.get_property(name) {
                     Ok(value) => values.push(value),
                     Err(e) => {
-                        log::error!("Failed to get property '{}' from lock surface: {}", name, e);
+                        logger::error!(
+                            "Failed to get property '{}' from lock surface: {}",
+                            name,
+                            e
+                        );
                         result = Err(Error::Domain(DomainError::Configuration {
                             message: format!("Failed to get property '{}': {}", name, e),
                         }));

--- a/crates/composition/src/selection.rs
+++ b/crates/composition/src/selection.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Error, LayerSurfaceHandle, Shell,
+    Error, LayerSurfaceHandle, Shell, logger,
     selector::{Selector, SurfaceInfo},
     slint_interpreter::{ComponentInstance, Value},
 };
@@ -153,7 +153,7 @@ impl<'a> Selection<'a> {
                     Ok(()) => result.add_success(()),
                     Err(e) => {
                         let error_msg = format!("Failed to set property '{}': {}", name, e);
-                        log::error!(
+                        logger::error!(
                             "{} on surface {}[{:?}]",
                             error_msg,
                             info.name,
@@ -179,7 +179,7 @@ impl<'a> Selection<'a> {
                     Ok(value) => result.add_success(value),
                     Err(e) => {
                         let error_msg = format!("Failed to get property '{}': {}", name, e);
-                        log::error!(
+                        logger::error!(
                             "{} on surface {}[{:?}]",
                             error_msg,
                             info.name,

--- a/crates/composition/src/session_lock.rs
+++ b/crates/composition/src/session_lock.rs
@@ -1,5 +1,6 @@
 use crate::IntoValue;
 use crate::calloop::channel;
+use crate::logger;
 use crate::slint_interpreter::Value;
 use crate::system::{SessionLockCommand, ShellCommand};
 use crate::{Error, Result};
@@ -37,7 +38,7 @@ impl SessionLock {
     }
 
     pub fn activate(&self) -> Result<()> {
-        log::info!("Session lock activation called - queuing SessionLockCommand::Activate");
+        logger::info!("Session lock activation called - queuing SessionLockCommand::Activate");
 
         self.command_sender
             .send(ShellCommand::SessionLock(SessionLockCommand::Activate {
@@ -50,12 +51,12 @@ impl SessionLock {
                 })
             })?;
 
-        log::info!("SessionLockCommand::Activate queued successfully");
+        logger::info!("SessionLockCommand::Activate queued successfully");
         Ok(())
     }
 
     pub fn deactivate(&self) -> Result<()> {
-        log::info!("Session lock deactivation called - queuing SessionLockCommand::Deactivate");
+        logger::info!("Session lock deactivation called - queuing SessionLockCommand::Deactivate");
 
         self.command_sender
             .send(ShellCommand::SessionLock(SessionLockCommand::Deactivate))
@@ -65,7 +66,7 @@ impl SessionLock {
                 })
             })?;
 
-        log::info!("SessionLockCommand::Deactivate queued successfully");
+        logger::info!("SessionLockCommand::Deactivate queued successfully");
         Ok(())
     }
 

--- a/crates/composition/src/shell.rs
+++ b/crates/composition/src/shell.rs
@@ -9,7 +9,7 @@ use crate::system::{
     ShellControl, SurfaceCommand, SurfaceTarget,
 };
 use crate::value_conversion::IntoValue;
-use crate::{Error, Result};
+use crate::{Error, Result, logger};
 use layer_shika_adapters::errors::EventLoopError;
 use layer_shika_adapters::platform::calloop::channel;
 use layer_shika_adapters::platform::slint_interpreter::{
@@ -393,7 +393,7 @@ impl Shell {
         compilation_result: Rc<CompilationResult>,
         definitions: Vec<SurfaceDefinition>,
     ) -> Result<Self> {
-        log::info!("Creating Shell with {} windows", definitions.len());
+        logger::info!("Creating Shell with {} windows", definitions.len());
 
         for def in &definitions {
             def.config.validate().map_err(Error::Domain)?;
@@ -401,7 +401,7 @@ impl Shell {
 
         match definitions.len() {
             0 => {
-                log::info!("Creating minimal shell without layer surfaces");
+                logger::info!("Creating minimal shell without layer surfaces");
                 Self::new_minimal(compilation_result)
             }
             1 => {
@@ -457,7 +457,7 @@ impl Shell {
 
         shell.setup_command_handler(receiver)?;
 
-        log::info!("Shell created (single-window mode)");
+        logger::info!("Shell created (single-window mode)");
 
         Ok(shell)
     }
@@ -524,7 +524,7 @@ impl Shell {
 
         shell.setup_command_handler(receiver)?;
 
-        log::info!(
+        logger::info!(
             "Shell created (multi-surface mode) with surfaces: {:?}",
             shell.surface_names()
         );
@@ -555,7 +555,7 @@ impl Shell {
 
         shell.setup_command_handler(receiver)?;
 
-        log::info!("Shell created (minimal mode - no layer surfaces)");
+        logger::info!("Shell created (minimal mode - no layer surfaces)");
 
         Ok(shell)
     }
@@ -582,7 +582,7 @@ impl Shell {
                         }
                         ShellCommand::Render => {
                             if let Err(e) = ctx.render_frame_if_dirty() {
-                                log::error!("Failed to render frame: {}", e);
+                                logger::error!("Failed to render frame: {}", e);
                             }
                         }
                     }
@@ -608,12 +608,12 @@ impl Shell {
         match command {
             PopupCommand::Show { handle, config } => {
                 if let Err(e) = ctx.show_popup(handle, &config) {
-                    log::error!("Failed to show popup: {}", e);
+                    logger::error!("Failed to show popup: {}", e);
                 }
             }
             PopupCommand::Close(handle) => {
                 if let Err(e) = ctx.close_popup(handle) {
-                    log::error!("Failed to close popup: {}", e);
+                    logger::error!("Failed to close popup: {}", e);
                 }
             }
             PopupCommand::Resize {
@@ -622,7 +622,7 @@ impl Shell {
                 height,
             } => {
                 if let Err(e) = ctx.resize_popup(handle, width, height) {
-                    log::error!("Failed to resize popup: {}", e);
+                    logger::error!("Failed to resize popup: {}", e);
                 }
             }
         }
@@ -638,19 +638,19 @@ impl Shell {
                 component_name,
                 config,
             } => {
-                log::info!("Processing SessionLockCommand::Activate");
+                logger::info!("Processing SessionLockCommand::Activate");
                 if let Err(e) = ctx.activate_session_lock(component_name, config.clone()) {
-                    log::error!("Failed to activate session lock: {}", e);
+                    logger::error!("Failed to activate session lock: {}", e);
                 } else {
-                    log::info!("Session lock activated successfully");
+                    logger::info!("Session lock activated successfully");
                 }
             }
             SessionLockCommand::Deactivate => {
-                log::info!("Processing SessionLockCommand::Deactivate");
+                logger::info!("Processing SessionLockCommand::Deactivate");
                 if let Err(e) = ctx.deactivate_session_lock() {
-                    log::error!("Failed to deactivate session lock: {}", e);
+                    logger::error!("Failed to deactivate session lock: {}", e);
                 } else {
-                    log::info!("Session lock deactivated successfully");
+                    logger::info!("Session lock deactivated successfully");
                 }
             }
         }
@@ -665,7 +665,7 @@ impl Shell {
                 if let Some(surface) = ctx.surface_by_instance_mut(id.surface(), id.output()) {
                     vec![surface]
                 } else {
-                    log::warn!(
+                    logger::warn!(
                         "Surface instance not found: handle {:?} on output {:?}",
                         id.surface(),
                         id.output()
@@ -687,7 +687,7 @@ impl Shell {
         width: u32,
         height: u32,
     ) {
-        log::debug!(
+        logger::debug!(
             "Surface command: Resize {:?} to {}x{}",
             target,
             width,
@@ -709,7 +709,7 @@ impl Shell {
     ) where
         F: Fn(&LayerSurfaceHandle<'_>),
     {
-        log::debug!("Surface command: {} {:?}", operation, target);
+        logger::debug!("Surface command: {} {:?}", operation, target);
         for surface in Self::resolve_surface_target(ctx, target) {
             let handle = LayerSurfaceHandle::from_window_state(surface);
             apply(&handle);
@@ -722,10 +722,10 @@ impl Shell {
         target: &SurfaceTarget,
         config: &SurfaceConfig,
     ) {
-        log::debug!("Surface command: ApplyConfig {:?}", target);
+        logger::debug!("Surface command: ApplyConfig {:?}", target);
 
         if let Err(e) = config.validate() {
-            log::error!("Invalid surface configuration: {}", e);
+            logger::error!("Invalid surface configuration: {}", e);
             return;
         }
 
@@ -787,22 +787,22 @@ impl Shell {
                 );
             }
             SurfaceCommand::SetOutputPolicy { target, policy } => {
-                log::debug!(
+                logger::debug!(
                     "Surface command: SetOutputPolicy {:?} to {:?}",
                     target,
                     policy
                 );
-                log::warn!(
+                logger::warn!(
                     "SetOutputPolicy is not yet implemented - requires runtime surface spawning"
                 );
             }
             SurfaceCommand::SetScaleFactor { target, factor } => {
-                log::debug!(
+                logger::debug!(
                     "Surface command: SetScaleFactor {:?} to {:?}",
                     target,
                     factor
                 );
-                log::warn!(
+                logger::warn!(
                     "SetScaleFactor is not yet implemented - requires runtime surface property updates"
                 );
             }
@@ -812,7 +812,7 @@ impl Shell {
         }
 
         if let Err(e) = ctx.render_frame_if_dirty() {
-            log::error!("Failed to render frame after surface command: {}", e);
+            logger::error!("Failed to render frame after surface command: {}", e);
         }
     }
 
@@ -869,7 +869,7 @@ impl Shell {
 
     /// Starts the event loop and runs the shell until exit
     pub fn run(&mut self) -> Result<()> {
-        log::info!(
+        logger::info!(
             "Starting Shell event loop with {} windows",
             self.registry.len()
         );
@@ -911,7 +911,7 @@ impl Shell {
         let entry = SurfaceEntry::new(surface_handle, definition.component.clone(), definition);
         self.registry.insert(entry)?;
 
-        log::info!(
+        logger::info!(
             "Spawned surface with handle {:?}, created {} output instances",
             surface_handle,
             handles.len()
@@ -931,7 +931,7 @@ impl Shell {
         let mut system = self.inner.borrow_mut();
         system.despawn_surface(&entry.name)?;
 
-        log::info!(
+        logger::info!(
             "Despawned surface '{}' with handle {:?}",
             entry.name,
             handle
@@ -1125,7 +1125,7 @@ impl Shell {
                             handler_rc(ctx).into_value()
                         })
                 {
-                    log::error!(
+                    logger::error!(
                         "Failed to register callback '{}' on surface '{}': {}",
                         callback_name,
                         surface_name,
@@ -1186,7 +1186,7 @@ impl Shell {
                             handler_rc(args, ctx).into_value()
                         })
                 {
-                    log::error!(
+                    logger::error!(
                         "Failed to register callback '{}' on surface '{}': {}",
                         callback_name,
                         surface_name,

--- a/crates/composition/src/system.rs
+++ b/crates/composition/src/system.rs
@@ -1,6 +1,6 @@
 use crate::event_loop::FromAppState;
 use crate::layer_surface::LayerSurfaceHandle;
-use crate::{Error, Result};
+use crate::{Error, Result, logger};
 use layer_shika_adapters::platform::calloop::channel;
 use layer_shika_adapters::platform::slint::ComponentHandle;
 use layer_shika_adapters::platform::slint_interpreter::{
@@ -739,16 +739,16 @@ impl EventDispatchContext<'_> {
     /// on the popup manager for immediate updates.
     #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
     pub fn show_popup(&mut self, handle: PopupHandle, config: &PopupConfig) -> Result<PopupHandle> {
-        log::info!("show_popup called for component '{}'", config.component);
+        logger::info!("show_popup called for component '{}'", config.component);
 
         let compilation_result = self.compilation_result().ok_or_else(|| {
-            log::error!("No compilation result available");
+            logger::error!("No compilation result available");
             Error::Domain(DomainError::Configuration {
                 message: "No compilation result available for popup creation".to_string(),
             })
         })?;
 
-        log::debug!(
+        logger::debug!(
             "Got compilation result, looking for component '{}'",
             config.component
         );
@@ -756,7 +756,7 @@ impl EventDispatchContext<'_> {
         let definition = compilation_result
             .component(&config.component)
             .ok_or_else(|| {
-                log::error!(
+                logger::error!(
                     "Component '{}' not found in compilation result",
                     config.component
                 );
@@ -765,17 +765,17 @@ impl EventDispatchContext<'_> {
                 })
             })?;
 
-        log::debug!("Found component definition for '{}'", config.component);
+        logger::debug!("Found component definition for '{}'", config.component);
 
         let is_using_active = self.app_state.active_output().is_some();
         let active_surface = self.active_or_primary_output().ok_or_else(|| {
-            log::error!("No active or primary output available");
+            logger::error!("No active or primary output available");
             Error::Domain(DomainError::OutputNotFound {
                 message: "No active or primary output available".to_string(),
             })
         })?;
 
-        log::info!(
+        logger::info!(
             "Creating popup on {} output",
             if is_using_active { "active" } else { "primary" }
         );
@@ -797,7 +797,7 @@ impl EventDispatchContext<'_> {
             };
         }
 
-        log::debug!(
+        logger::debug!(
             "Creating popup for '{}' with dimensions {}x{} at position {:?}",
             config.component,
             initial_dimensions.0,
@@ -877,7 +877,7 @@ impl EventDispatchContext<'_> {
 
                 popup_manager.update_popup_viewport(handle.key(), logical_width, logical_height);
                 popup_manager.commit_popup_surface(handle.key());
-                log::debug!(
+                logger::debug!(
                     "Updated popup viewport to logical size: {}x{} (from resize to {}x{})",
                     logical_width,
                     logical_height,
@@ -977,7 +977,7 @@ impl EventDispatchContext<'_> {
                 let dimensions = extract_dimensions_from_callback(args);
                 let popup_key = key_cell.get();
 
-                log::info!(
+                logger::info!(
                     "Resize callback invoked: {}x{} for key {}",
                     dimensions.width,
                     dimensions.height,
@@ -1001,7 +1001,7 @@ impl EventDispatchContext<'_> {
                                 logical_width,
                                 logical_height,
                             );
-                            log::debug!(
+                            logger::debug!(
                                 "Updated popup viewport to logical size: {}x{} (from direct resize to {}x{})",
                                 logical_width,
                                 logical_height,


### PR DESCRIPTION
Allow using `tracing` as a logging back-end, without including `log` in the final binary.

Built with `cargo b --no-default-features --features use-tracing`.