### PR TITLE
Input region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
  "layer-shika-adapters",
  "layer-shika-domain",
  "log",
+ "smithay-client-toolkit 0.20.0",
  "spin_on",
  "thiserror 2.0.17",
 ]
@@ -3647,6 +3648,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "surface-input-region"
+version = "0.3.1"
+dependencies = [
+ "env_logger",
+ "layer-shika",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "examples/session-lock-selectors",
     "examples/session-lock-standalone",
     "examples/simple-popup",
+    "examples/surface-input-region",
 ]
 
 [workspace.package]

--- a/crates/adapters/src/wayland/event_handling/app_dispatcher.rs
+++ b/crates/adapters/src/wayland/event_handling/app_dispatcher.rs
@@ -18,8 +18,8 @@ use wayland_client::{
         wl_keyboard::{self, WlKeyboard},
         wl_output::{self, WlOutput},
         wl_pointer::{self, WlPointer},
-        wl_registry::Event,
-        wl_registry::WlRegistry,
+        wl_region::WlRegion,
+        wl_registry::{Event, WlRegistry},
         wl_seat::WlSeat,
         wl_surface::WlSurface,
     },
@@ -716,6 +716,7 @@ macro_rules! impl_empty_dispatch_app {
 impl_empty_dispatch_app!(
     (WlCompositor, ()),
     (WlSurface, ()),
+    (WlRegion, ()),
     (ZwlrLayerShellV1, ()),
     (ExtSessionLockManagerV1, ()),
     (WlSeat, ()),

--- a/crates/adapters/src/wayland/managed_proxies.rs
+++ b/crates/adapters/src/wayland/managed_proxies.rs
@@ -89,6 +89,10 @@ impl ManagedWlSurface {
             connection,
         }
     }
+
+    pub const fn inner(&self) -> &Rc<WlSurface> {
+        &self.surface
+    }
 }
 
 impl Deref for ManagedWlSurface {

--- a/crates/adapters/src/wayland/surfaces/app_state.rs
+++ b/crates/adapters/src/wayland/surfaces/app_state.rs
@@ -1,3 +1,23 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::os::fd::BorrowedFd;
+use std::rc::Rc;
+
+use layer_shika_domain::entities::output_registry::OutputRegistry;
+use layer_shika_domain::value_objects::handle::SurfaceHandle;
+use layer_shika_domain::value_objects::lock_config::LockConfig;
+use layer_shika_domain::value_objects::lock_state::LockState;
+use layer_shika_domain::value_objects::output_handle::OutputHandle;
+use layer_shika_domain::value_objects::output_info::OutputInfo;
+use slint_interpreter::{CompilationResult, ComponentDefinition, Value};
+use wayland_client::Proxy;
+use wayland_client::backend::ObjectId;
+use wayland_client::protocol::wl_keyboard;
+use wayland_client::protocol::wl_output::WlOutput;
+use wayland_client::protocol::wl_region::WlRegion;
+use wayland_client::protocol::wl_surface::WlSurface;
+use xkbcommon::xkb;
+
 use super::event_context::SharedPointerSerial;
 use super::keyboard_state::KeyboardState;
 use super::surface_state::SurfaceState;
@@ -17,23 +37,6 @@ use crate::wayland::session_lock::manager::callbacks::{
 use crate::wayland::session_lock::{
     LockCallback, LockPropertyOperation, OutputFilter, SessionLockManager,
 };
-use layer_shika_domain::entities::output_registry::OutputRegistry;
-use layer_shika_domain::value_objects::handle::SurfaceHandle;
-use layer_shika_domain::value_objects::lock_config::LockConfig;
-use layer_shika_domain::value_objects::lock_state::LockState;
-use layer_shika_domain::value_objects::output_handle::OutputHandle;
-use layer_shika_domain::value_objects::output_info::OutputInfo;
-use slint_interpreter::{CompilationResult, ComponentDefinition, Value};
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::os::fd::BorrowedFd;
-use std::rc::Rc;
-use wayland_client::Proxy;
-use wayland_client::backend::ObjectId;
-use wayland_client::protocol::wl_keyboard;
-use wayland_client::protocol::wl_region::WlRegion;
-use wayland_client::protocol::{wl_output::WlOutput, wl_surface::WlSurface};
-use xkbcommon::xkb;
 
 pub type PerOutputSurface = SurfaceState;
 type SessionLockCallback = Rc<dyn Fn(&[Value]) -> Value>;

--- a/crates/adapters/src/wayland/surfaces/app_state.rs
+++ b/crates/adapters/src/wayland/surfaces/app_state.rs
@@ -31,6 +31,7 @@ use std::rc::Rc;
 use wayland_client::Proxy;
 use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_keyboard;
+use wayland_client::protocol::wl_region::WlRegion;
 use wayland_client::protocol::{wl_output::WlOutput, wl_surface::WlSurface};
 use xkbcommon::xkb;
 
@@ -954,6 +955,13 @@ impl AppState {
             .retain(|_, k| !matching_handles.contains(&k.surface_handle));
 
         removed
+    }
+
+    pub fn create_region(&self) -> Option<WlRegion> {
+        let queue = self.queue_handle.as_ref()?;
+        let ctx = self.global_context.as_ref()?;
+        let region = ctx.compositor.create_region(queue, ());
+        Some(region)
     }
 }
 

--- a/crates/adapters/src/wayland/surfaces/rendering_state.rs
+++ b/crates/adapters/src/wayland/surfaces/rendering_state.rs
@@ -4,7 +4,8 @@ use crate::rendering::femtovg::renderable_window::RenderableWindow;
 use crate::wayland::surfaces::surface_renderer::{SurfaceRenderer, SurfaceRendererParams};
 use slint::PhysicalSize;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
-use crate::wayland::managed_proxies::ManagedWpFractionalScaleV1;
+use wayland_client::protocol::wl_surface::WlSurface;
+use crate::wayland::managed_proxies::{ManagedWpFractionalScaleV1};
 
 pub struct RenderingState<W: RenderableWindow> {
     renderer: SurfaceRenderer<W>,
@@ -44,6 +45,10 @@ impl<W: RenderableWindow> RenderingState<W> {
 
     pub fn layer_surface(&self) -> Rc<ZwlrLayerSurfaceV1> {
         self.renderer.layer_surface()
+    }
+
+    pub fn surface(&self) -> Rc<WlSurface> {
+        self.renderer.surface()
     }
 
     pub fn fractional_scale(&self) -> Option<&ManagedWpFractionalScaleV1> {

--- a/crates/adapters/src/wayland/surfaces/surface_renderer.rs
+++ b/crates/adapters/src/wayland/surfaces/surface_renderer.rs
@@ -8,6 +8,7 @@ use layer_shika_domain::surface_dimensions::SurfaceDimensions;
 use log::{error, info};
 use slint::PhysicalSize;
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
+use wayland_client::protocol::wl_surface::WlSurface;
 use std::rc::Rc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +64,10 @@ impl<W: RenderableWindow> SurfaceRenderer<W> {
 
     pub fn layer_surface(&self) -> Rc<ZwlrLayerSurfaceV1> {
         Rc::clone(self.layer_surface.inner())
+    }
+
+    pub fn surface(&self) -> Rc<WlSurface> {
+        Rc::clone(self.surface.inner())
     }
 
     pub const fn height(&self) -> u32 {

--- a/crates/adapters/src/wayland/surfaces/surface_state.rs
+++ b/crates/adapters/src/wayland/surfaces/surface_state.rs
@@ -20,6 +20,7 @@ use slint::{LogicalPosition, PhysicalSize};
 use slint::platform::WindowEvent;
 use slint_interpreter::{ComponentInstance, CompilationResult};
 use smithay_client_toolkit::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
+use wayland_client::protocol::wl_region::WlRegion;
 use wayland_client::{
     Proxy,
     backend::ObjectId,
@@ -199,6 +200,13 @@ impl SurfaceState {
             .borrow_mut()
             .update_output_size(output_size);
         self.event_context.borrow().update_output_size(output_size);
+    }
+
+    pub fn set_input_region(&mut self, region: &WlRegion) {
+        self.rendering.surface().set_input_region(Some(region));
+        self.rendering.surface().commit();
+
+        region.destroy();
     }
 
     pub fn output_size(&self) -> PhysicalSize {

--- a/crates/composition/Cargo.toml
+++ b/crates/composition/Cargo.toml
@@ -18,4 +18,5 @@ layer-shika-adapters.workspace = true
 layer-shika-domain.workspace = true
 log.workspace = true
 spin_on.workspace = true
+smithay-client-toolkit.workspace = true
 thiserror.workspace = true

--- a/crates/composition/src/shell.rs
+++ b/crates/composition/src/shell.rs
@@ -681,6 +681,31 @@ impl Shell {
         }
     }
 
+    fn apply_surface_resize_input_region(
+        ctx: &mut EventDispatchContext<'_>,
+        target: &SurfaceTarget,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) {
+        log::debug!(
+            "Surface command: Resize {:?} to x{}y{} {}x{} ",
+            target,
+            x,
+            y,
+            width,
+            height
+        );
+        let region = &ctx.create_region();
+        for surface in Self::resolve_surface_target(ctx, target) {
+            if let Some(r) = region {
+                r.add(x, y, width, height);
+                surface.set_input_region(r);
+            }
+        }
+    }
+
     fn apply_surface_resize(
         ctx: &mut EventDispatchContext<'_>,
         target: &SurfaceTarget,
@@ -795,6 +820,15 @@ impl Shell {
                 log::warn!(
                     "SetOutputPolicy is not yet implemented - requires runtime surface spawning"
                 );
+            }
+            SurfaceCommand::SetInputRegion {
+                target,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                Self::apply_surface_resize_input_region(ctx, &target, x, y, width, height);
             }
             SurfaceCommand::SetScaleFactor { target, factor } => {
                 log::debug!(

--- a/crates/composition/src/system.rs
+++ b/crates/composition/src/system.rs
@@ -23,6 +23,7 @@ use layer_shika_domain::value_objects::popup_config::PopupConfig;
 use layer_shika_domain::value_objects::popup_position::PopupPosition;
 use layer_shika_domain::value_objects::popup_size::PopupSize;
 use layer_shika_domain::value_objects::surface_instance_id::SurfaceInstanceId;
+use smithay_client_toolkit::reexports::client::protocol::wl_region::WlRegion;
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -72,6 +73,13 @@ pub enum SurfaceCommand {
     SetOutputPolicy {
         target: SurfaceTarget,
         policy: OutputPolicy,
+    },
+    SetInputRegion {
+        target: SurfaceTarget,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
     },
     SetScaleFactor {
         target: SurfaceTarget,
@@ -389,6 +397,19 @@ impl SurfaceControlHandle {
             .send(ShellCommand::Surface(SurfaceCommand::SetOutputPolicy {
                 target: self.target.clone(),
                 policy,
+            }))
+            .map_err(|_| Error::Domain(DomainError::ChannelClosed))
+    }
+
+    /// Sets the input region for the surface
+    pub fn set_input_region(&self, x: i32, y: i32, width: i32, height: i32) -> Result<()> {
+        self.sender
+            .send(ShellCommand::Surface(SurfaceCommand::SetInputRegion {
+                target: self.target.clone(),
+                x,
+                y,
+                width,
+                height,
             }))
             .map_err(|_| Error::Domain(DomainError::ChannelClosed))
     }
@@ -1046,5 +1067,9 @@ impl EventDispatchContext<'_> {
             let component = surface.component_instance();
             f(component, handle);
         }
+    }
+
+    pub fn create_region(&self) -> Option<WlRegion> {
+        self.app_state.create_region()
     }
 }

--- a/crates/composition/src/system.rs
+++ b/crates/composition/src/system.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
 use layer_shika_adapters::platform::calloop::channel;
 use layer_shika_adapters::platform::slint::ComponentHandle;
 use layer_shika_adapters::platform::slint_interpreter::{
@@ -20,8 +23,6 @@ use layer_shika_domain::value_objects::popup_position::PopupPosition;
 use layer_shika_domain::value_objects::popup_size::PopupSize;
 use layer_shika_domain::value_objects::surface_instance_id::SurfaceInstanceId;
 use smithay_client_toolkit::reexports::client::protocol::wl_region::WlRegion;
-use std::cell::Cell;
-use std::rc::Rc;
 
 use crate::event_loop::FromAppState;
 use crate::layer_surface::LayerSurfaceHandle;

--- a/crates/composition/src/system.rs
+++ b/crates/composition/src/system.rs
@@ -1,6 +1,3 @@
-use std::cell::Cell;
-use std::rc::Rc;
-
 use layer_shika_adapters::platform::calloop::channel;
 use layer_shika_adapters::platform::slint::ComponentHandle;
 use layer_shika_adapters::platform::slint_interpreter::{

--- a/examples/surface-input-region/Cargo.toml
+++ b/examples/surface-input-region/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "surface-input-region"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+layer-shika = { path = "../.." }
+env_logger = "0.11.7"
+log.workspace = true

--- a/examples/surface-input-region/README.md
+++ b/examples/surface-input-region/README.md
@@ -1,0 +1,9 @@
+# Surface Input Region Example
+
+This example demonstrates usage of Wayland's [set_input_region](https://wayland.app/protocols/wayland#wl_surface:request:set_input_region) functionality to make surface partially transparent for pointer clicks.
+
+## Running
+
+```bash
+cargo run -p surface-input-region
+```

--- a/examples/surface-input-region/src/main.rs
+++ b/examples/surface-input-region/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
 
     let ui_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui/ui.slint");
 
-    let compiled = Shell::compile_file(&ui_path).expect("Compilation error");
+    let compiled = Shell::compile_file(&ui_path)?;
 
     let mut shell = Shell::from_compilation(compiled)
         .surface("MainWindow")
@@ -24,15 +24,18 @@ fn main() -> Result<()> {
     shell
         .select(Surface::named("MainWindow"))
         .on_callback_with_args("width-changed", |args, ctx| {
-            let Value::Number(width) = args[0] else {
+            let Some(Value::Number(width)) = args.first() else {
                 log::error!("MainWindow.width-changed provided no width");
                 return;
             };
 
+            #[allow(clippy::cast_possible_truncation)]
+            let width_i32 = *width as i32;
+
             if let Err(e) =
                 ctx.control()
                     .surface("MainWindow")
-                    .set_input_region(0, 0, width as i32, 32)
+                    .set_input_region(0, 0, width_i32, 32)
             {
                 log::error!("Failed to set_input_region: {e}");
             }

--- a/examples/surface-input-region/src/main.rs
+++ b/examples/surface-input-region/src/main.rs
@@ -1,0 +1,43 @@
+use layer_shika::{prelude::*, slint_interpreter::Value};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    log::info!("Starting surface-input-region example");
+
+    let ui_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui/ui.slint");
+
+    let compiled = Shell::compile_file(&ui_path).expect("Compilation error");
+
+    let mut shell = Shell::from_compilation(compiled)
+        .surface("MainWindow")
+        .height(64)
+        .anchor(AnchorEdges::top_bar())
+        .exclusive_zone(32)
+        .namespace("surface-input-region-example")
+        .build()?;
+
+    // Hacky way to get a surface size because `init` callback is called before Shell::run()
+    shell
+        .select(Surface::named("MainWindow"))
+        .on_callback_with_args("width-changed", |args, ctx| {
+            let Value::Number(width) = args[0] else {
+                log::error!("MainWindow.width-changed provided no width");
+                return;
+            };
+
+            if let Err(e) =
+                ctx.control()
+                    .surface("MainWindow")
+                    .set_input_region(0, 0, width as i32, 32)
+            {
+                log::error!("Failed to set_input_region: {e}");
+            }
+        });
+
+    shell.run()?;
+    Ok(())
+}

--- a/examples/surface-input-region/src/main.rs
+++ b/examples/surface-input-region/src/main.rs
@@ -1,5 +1,7 @@
-use layer_shika::{prelude::*, slint_interpreter::Value};
 use std::path::PathBuf;
+
+use layer_shika::prelude::*;
+use layer_shika::slint_interpreter::Value;
 
 fn main() -> Result<()> {
     env_logger::builder()
@@ -32,10 +34,10 @@ fn main() -> Result<()> {
             #[allow(clippy::cast_possible_truncation)]
             let width_i32 = *width as i32;
 
-            if let Err(e) =
-                ctx.control()
-                    .surface("MainWindow")
-                    .set_input_region(0, 0, width_i32, 32)
+            if let Err(e) = ctx
+                .control()
+                .surface("MainWindow")
+                .set_input_region(0, 0, width_i32, 32)
             {
                 log::error!("Failed to set_input_region: {e}");
             }

--- a/examples/surface-input-region/ui/ui.slint
+++ b/examples/surface-input-region/ui/ui.slint
@@ -1,0 +1,47 @@
+import { Button } from "std-widgets.slint";
+export component MainWindow inherits Window {
+    height: 32px;
+    background: transparent;
+
+    Rectangle {
+        background: white;
+        y: 0px;
+        height: 32px;
+        width <=> root.width;
+
+        VerticalLayout {
+            alignment: center;
+            HorizontalLayout {
+                alignment: center;
+                Text {
+                    text: "This area is exclusive";
+                    color: black;
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        background: rgba(0,0,0,0.5);
+        y: 32px;
+        height: 32px;
+        width <=> root.width;
+
+        VerticalLayout {
+            alignment: center;
+            HorizontalLayout {
+                alignment: center;
+                Text {
+                    text: "This area is transparent for the pointer";
+                    color: white;
+                }
+            }
+        }
+    }
+
+    callback width-changed(length);
+
+    changed width => {
+        width-changed(root.width);
+    }
+}


### PR DESCRIPTION
This PR implements possibility to set a input region (see https://wayland.app/protocols/wayland#wl_surface:request:set_input_region) via SurfaceControlHandle::set_input_region